### PR TITLE
Udate pagination logic in Course Browser page

### DIFF
--- a/lib/features/course browser/browser_view.dart
+++ b/lib/features/course browser/browser_view.dart
@@ -10,11 +10,12 @@ import '../../shared/utils/and.dart';
 import 'subject_screen.dart';
 
 class BrowserView extends StatefulWidget {
-  const BrowserView(
-      {super.key,
-      required this.albiruni,
-      required this.kulliyah,
-      this.courseCode});
+  const BrowserView({
+    super.key,
+    required this.albiruni,
+    required this.kulliyah,
+    this.courseCode,
+  });
 
   final Albiruni albiruni;
   final String kulliyah;
@@ -25,6 +26,8 @@ class BrowserView extends StatefulWidget {
 }
 
 class _BrowserViewState extends State<BrowserView> {
+  int currentCourseTotalPage =
+      double.maxFinite.toInt(); // start with 'infinity' value
   int _page = 1;
 
   @override
@@ -74,8 +77,9 @@ class _BrowserViewState extends State<BrowserView> {
   }
 
   Future<List<Subject>> _getSubjects() async {
-    var (subjects, _) = await widget.albiruni
+    var (subjects, totalPage) = await widget.albiruni
         .fetch(widget.kulliyah, course: widget.courseCode, page: _page);
+    currentCourseTotalPage = totalPage;
     return subjects;
   }
 
@@ -105,9 +109,11 @@ class _BrowserViewState extends State<BrowserView> {
             Center(child: Text(_page.toString())),
             IconButton(
                 tooltip: "Next page",
-                onPressed: () {
-                  setState(() => _page++);
-                },
+                onPressed: _page >= currentCourseTotalPage
+                    ? null
+                    : () {
+                        setState(() => _page++);
+                      },
                 icon: const Icon(Icons.navigate_next_outlined))
           ],
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: "direct main"
     description:
       name: albiruni
-      sha256: "71682edd5752c73614497d261975c52f2cd6b148693680db8fcb80eae6600e8b"
+      sha256: d925143a7a4fdacfde3df25768682dbd5706ff6600a65ffd8bb7c105bd631f3f
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   analyzer:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR updates the navigation button to stops at `totalPage` (this was returned from albiruni). So we don't access the page that doesn't exist. Closes #45 

Demo:

https://github.com/user-attachments/assets/39fb0096-f54e-4d7d-9950-327742f0b8f6

One limitation that, if the page only consists of a single page, the app will always go to page 2. Because it doesn't know the total page initially.